### PR TITLE
Allow CentOS7 to work with /64 Pools

### DIFF
--- a/docs/networking/linux-static-ip-configuration.md
+++ b/docs/networking/linux-static-ip-configuration.md
@@ -118,7 +118,15 @@ The default ethernet interface file is located at `/etc/sysconfig/network-script
     # Edit from "yes" to "no":
     PEERDNS=no
 
-    ...
+    # Keep the following lines:
+    DEVICE="eth0"
+    NAME="eth0"
+    ONBOOT="yes"
+    IPV6INIT="yes"
+    IPV6_ADDR_GEN_MODE="eui64"
+    IPV6_PRIVACY="no"
+    
+    
 
     # Add the following lines:
     DOMAIN=members.linode.com


### PR DESCRIPTION
Configuration file was causing the addition of IPv6 addresses from /64 pools to fail silently